### PR TITLE
bugfix: _cleanup_no_samples 使用归一化标签替代中文字符串直接比较

### DIFF
--- a/ai_runner.py
+++ b/ai_runner.py
@@ -859,7 +859,8 @@ class WorkflowAIProcessor:
         missing_dirs: list[str] = []
         failed_dirs: list[dict[str, str]] = []
         for item in sequence_results:
-            if item.get("collision_pred") != "否":
+            label = to_analysis_label(item.get("collision_pred"))
+            if label != "no":
                 continue
             sample_name = item.get("sample_name")
             if not sample_name:


### PR DESCRIPTION
## 问题
`_cleanup_no_samples` 中 `collision_pred != "否"` 直接比较中文字符，但 AI 可能返回英文 `"no"`，导致这些 sample 不会被清理。

## 修复
改用 `to_analysis_label()` 归一化后比较，与 `_build_retained_samples` 保持一致。

## 影响范围
- `ai_runner.py`: `_cleanup_no_samples` 方法