### PR TITLE
bugfix: _decode_with_context_stream 中间文件使用配置的 image_ext

### DIFF
--- a/frame.py
+++ b/frame.py
@@ -325,7 +325,7 @@ class MultiFrameDecoder:
                     if payload:
                         f.write(payload)
 
-            out_pattern = frames_dir / "frame_%04d.png"
+            out_pattern = frames_dir / f"frame_%04d.{self.image_ext}"
             cmd = [
                 self.ffmpeg_path,
                 "-y",
@@ -335,7 +335,7 @@ class MultiFrameDecoder:
             ]
             proc = subprocess.run(cmd, capture_output=True, text=True)
 
-            generated = sorted(frames_dir.glob("frame_*.png"))
+            generated = sorted(frames_dir.glob(f"frame_*.{self.image_ext}"))
             if proc.returncode == 0 and generated:
                 shutil.copyfile(generated[-1], output_path)
                 return True


### PR DESCRIPTION
## 问题
中间帧文件硬编码为 `.png`，当 `image_ext` 配置为其他格式时，`shutil.copyfile` 会将 PNG 内容复制到非 `.png` 扩展名文件，导致文件头与扩展名不一致。

## 修复
中间文件的输出模式和 glob 匹配均改为使用 `self.image_ext`。

## 影响范围
- `frame.py`: `_decode_with_context_stream` 方法