### PR TITLE
bugfix: _run_workflow_streaming 将 raw_fp 打开移入 try 块

### DIFF
--- a/ai_runner.py
+++ b/ai_runner.py
@@ -649,7 +649,7 @@ class WorkflowAIProcessor:
         save_raw_events_ndjson = bool(self.runtime_cfg.get("save_raw_events_ndjson", True))
 
         raw_events_path = ai_dir / "workflow_raw_events.ndjson"
-        raw_fp = raw_events_path.open("w", encoding="utf-8") if save_raw_events_ndjson else None
+        raw_fp = None
 
         result: dict[str, Any] = {
             "workflow_run_id": None,
@@ -671,6 +671,7 @@ class WorkflowAIProcessor:
         }
 
         try:
+            raw_fp = raw_events_path.open("w", encoding="utf-8") if save_raw_events_ndjson else None
             with client.stream(
                 "POST",
                 f"{self.api_cfg['base_url'].rstrip('/')}/workflows/run",


### PR DESCRIPTION
## 问题
`raw_fp` 在 `try` 块之前打开，若中间代码抛异常，`finally` 不会执行导致文件句柄泄漏。

## 修复
将 `raw_fp = ...open(...)` 移入 `try` 块内部，确保 `finally` 始终能关闭句柄。

## 影响范围
- `ai_runner.py`: `_run_workflow_streaming` 方法