### PR TITLE
bugfix: _finalize_row 保留 task result 完整字段

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -449,15 +449,11 @@ class RowWorkflow:
             if item is None:
                 updated_tasks.append(task)
                 continue
-            updated_tasks.append({
-                "task_id": task.get("task_id"),
-                "target_ts": task.get("target_ts"),
-                "status": item.get("status"),
-                "task_dir": item.get("task_dir"),
-                "manifest_path": item.get("manifest_path"),
-                "ai_status": (item.get("ai") or {}).get("status") if isinstance(item.get("ai"), dict) else None,
-                "error": item.get("error"),
-            })
+            merged = dict(task)
+            merged.update(item)
+            merged["ai_status"] = (item.get("ai") or {}).get("status") if isinstance(item.get("ai"), dict) else None
+            merged.pop("ai", None)
+            updated_tasks.append(merged)
         row_meta["tasks"] = updated_tasks
 
         total_tasks = len(results)


### PR DESCRIPTION
## 问题
原实现仅保留 7 个硬编码字段，丢弃了 `decode_summary`、`frames_root` 等信息。后续如有代码依赖 `row_meta.json` 中的这些字段会出问题。

## 修复
以原始 task 为基础 `dict(task)`，合并 result 全部字段，仅摘出 `ai_status` 并移除重量级 `ai` 对象。

## 影响范围
- `workflow.py`: `_finalize_row` 方法