### PR TITLE
bugfix: stop_mode 终止后等待进程退出，超时则强制 kill

### DIFF
--- a/monitor_gui.py
+++ b/monitor_gui.py
@@ -167,7 +167,12 @@ class MonitorApp:
             self._append_log("[INFO] 当前无运行中的任务。")
             return
         self.proc.terminate()
-        self._append_log("[INFO] 已发送终止信号。")
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(timeout=3)
+        self._append_log("[INFO] 已终止任务。")
 
     def _drain_output(self, proc: subprocess.Popen, mode: str) -> None:
         if proc.stdout is not None:


### PR DESCRIPTION
## 问题
`terminate()` 后 `_drain_output` 线程可能因 `stdout.readline()` 阻塞而挂起。用户点停止后再点开始时，旧线程可能仍在运行。

## 修复
`terminate()` 后增加 `wait(timeout=5)` 等待进程退出，超时后 `kill()` 强制终止，确保管道关闭、drain 线程正常结束。

## 影响范围
- `monitor_gui.py`: `stop_mode` 方法