### PR TITLE
bugfix: 下载请求移除 Content-Type: application/json

### DIFF
--- a/bag.py
+++ b/bag.py
@@ -64,7 +64,6 @@ class DIBagDownloader:
 
         self.session = requests.Session()
         self.common_headers = {
-            "Content-Type": "application/json",
             "Accept-Language": "zh-CN",
             **self.browser_headers,
         }
@@ -450,7 +449,7 @@ class DIBagDownloader:
         save_dir.mkdir(parents=True, exist_ok=True)
         save_path = save_dir / save_name
         url = obs_download_url + "/obs/v1/files/download?opid=" + obs_id
-        headers = self._headers_for("rivulet")
+        headers = self._headers_for("rivulet", json_body=False)
         last_error: Exception | None = None
         max_attempts = max(1, self.download_retry_times + 1)
 
@@ -548,9 +547,11 @@ class DIBagDownloader:
             return core + "/archive/" + topic + ".bag"
         return core + "archive/" + topic + ".bag"
 
-    def _headers_for(self, platform: str) -> dict[str, str]:
+    def _headers_for(self, platform: str, json_body: bool = True) -> dict[str, str]:
         headers = dict(self.common_headers)
         headers["Deepdata-platform"] = platform
+        if json_body:
+            headers["Content-Type"] = "application/json"
         return headers
 
 


### PR DESCRIPTION
## 问题
`common_headers` 中的 `Content-Type: application/json` 会污染 GET 下载请求，部分服务器可能据此返回 JSON 错误响应而非文件流。

## 修复
将 `Content-Type` 从公共头移除，`_headers_for` 新增 `json_body` 参数（默认 True），仅在 JSON POST 请求时添加。下载调用传 `json_body=False`。

## 影响范围
- `bag.py`: `common_headers`、`_headers_for`、`_download_by_obs_id`