### PR TITLE
bugfix: _looks_like_zip 移除 zipfile.is_zipfile 误判导致所有 bag 下载异常

### DIFF
--- a/bag.py
+++ b/bag.py
@@ -488,16 +488,7 @@ class DIBagDownloader:
 
     @staticmethod
     def _looks_like_zip(content: bytes) -> bool:
-        if len(content) < 4:
-            return False
-        zip_magic_set = {
-            b"PK\x03\x04",  # local file header
-            b"PK\x05\x06",  # end of central directory (可能是空 zip)
-            b"PK\x07\x08",  # spanned/split zip
-        }
-        if content[:4] in zip_magic_set:
-            return True
-        return zipfile.is_zipfile(io.BytesIO(content))
+        return len(content) >= 4 and content[:4] == b"PK\x03\x04"
 
     @staticmethod
     def _validate_bag_magic(content: bytes, save_name: str, source: str) -> None:


### PR DESCRIPTION
## 问题（关键 Bug）
所有 bag 下载均报异常。

## 根因
`zipfile.is_zipfile()` 扫描整个文件内容寻找 End of Central Directory（EOCD）签名 `PK\x05\x06`。ROS bag 是大体积二进制文件，数据载荷中大概率包含与该签名碰撞的字节序列，导致：

1. 合法 `.bag` 文件（`#ROSBAG` 头）被误判为 zip
2. 进入 zip 解压路径 → 找不到 `.bag` 成员 → 抛出 RuntimeError
3. 所有 bag 均报下载异常

此外 `PK\x05\x06`（空 zip）和 `PK\x07\x08`（分卷 zip）在此场景下也无实际意义。

## 修复
仅检查文件头 4 字节是否为 `PK\x03\x04`（ZIP Local File Header），移除其他 magic 和 `zipfile.is_zipfile()` fallback。

## 影响范围
- `bag.py`: `_looks_like_zip` 静态方法（10 行 → 1 行）